### PR TITLE
[#ISSUE 94] Fix multi name server error

### DIFF
--- a/rocketmq/client.py
+++ b/rocketmq/client.py
@@ -230,6 +230,9 @@ class Producer(object):
     def set_group(self, group_name):
         ffi_check(dll.SetProducerGroupName(self._handle, _to_bytes(group_name)))
 
+    def set_instance_name(self, name):
+        ffi_check(dll.SetProducerInstanceName(self._handle, _to_bytes(name)))
+
     def set_name_server_address(self, addr):
         ffi_check(dll.SetProducerNameServerAddress(self._handle, _to_bytes(addr)))
 


### PR DESCRIPTION
## What is the purpose of the change

if you create two producer on two different name server in one process, the second producer will overwrite the name server of first producer, because they have the same instance name.

## Brief changelog

add set_instance_name function for producer, which has already in the ffi.py, but not exposed in client.py

## Verifying this change

XXXX


